### PR TITLE
fix: remove project parser option from eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,11 +4,6 @@ module.exports = (async function config() {
     ...txoPackageConfigList.configList,
     {
       files: ['sample/**/*.ts'],
-      languageOptions: {
-        parserOptions: {
-          project: './sample/tsconfig.json',
-        },
-      },
       settings: {
         'import/resolver': {
           typescript: {

--- a/sample/MultipleAttributesRedux.ts
+++ b/sample/MultipleAttributesRedux.ts
@@ -52,4 +52,5 @@ export const redux = createRedux<State, keyof Handlers<State>, Handlers<State>>(
 })
 
 export const type = redux.types.setFirst
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample attribute value
 redux.creators.setFirst({ first: { a: 1 } })

--- a/src/Redux/Model/Redux.ts
+++ b/src/Redux/Model/Redux.ts
@@ -126,7 +126,6 @@ export const createReduxAdvanced = <
       attributes.initialState,
       handlersKeys.reduce<Record<string, ReduxHandler<INNER_STATE>>>(
         (handlerMap, handlerKey) => {
-          // eslint-disable-next-line @typescript-eslint/prefer-destructuring -- we need to assign a value to handlerMap
           handlerMap[types[handlerKey]] = handlers[handlerKey]
           return handlerMap
         },
@@ -162,13 +161,11 @@ export const combineRedux = (reduxMap: NodeReduxMap): {
   reducer: Reducer, // TODO: fix Reducer<$ObjMap<typeof reduxMap, <S>(r: Reducer<S, any>) => S>, *>,
 } => ({
   filter: Object.keys(reduxMap).reduce<Record<string, FilterNode>>((filterMap, key) => {
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring -- we need to assign a value to filterMap
     filterMap[key] = reduxMap[key].filter
     return filterMap
   }, {}),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- reducer action is any
   reducer: combineReducers(Object.keys(reduxMap).reduce<Record<string, Reducer<unknown, any>>>((reducerMap, key) => {
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring -- we need to assign a value to reducerMap
     reducerMap[key] = reduxMap[key].reducer
     return reducerMap
   }, {})),

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,13 +515,13 @@
   dependencies:
     tslib "^2.4.0"
 
-"@eslint-community/eslint-plugin-eslint-comments@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.5.0.tgz#4ffa576583bd99dfbaf74c893635e2c76acba048"
-  integrity sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg==
+"@eslint-community/eslint-plugin-eslint-comments@^4.7.2":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz#1e6582d517847a589f11c7f2fbba1fde765cd127"
+  integrity sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==
   dependencies:
     escape-string-regexp "^4.0.0"
-    ignore "^5.2.4"
+    ignore "^7.0.5"
 
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.5.0", "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.0"
@@ -3108,11 +3108,11 @@ eslint-config-txo-package-typescript@^1.0.118:
     eslint-config-txo-typescript "^7.4.113"
 
 eslint-config-txo-typescript@^7.4.113:
-  version "7.4.113"
-  resolved "https://registry.yarnpkg.com/eslint-config-txo-typescript/-/eslint-config-txo-typescript-7.4.113.tgz#4efc1494f46e32c930f7e394885ac433a9580d91"
-  integrity sha512-/aMh0MxV94n3LJR4qRp1S27IKfyAcnBYNZjEt9t92jN6XDSb5M5xE4TBBhbdKCpEK3mtuGcgRWaB4a7uVhsotw==
+  version "7.4.118"
+  resolved "https://registry.yarnpkg.com/eslint-config-txo-typescript/-/eslint-config-txo-typescript-7.4.118.tgz#ead334a1a39d4e049e7ece9ba31fd10efc9f819b"
+  integrity sha512-L0trF3WdGa9ZgXQVAV0aPpJhtOojyEvEI7/KfnHSPzJq65eCX3na+404sj3dTlUkhRiJwhriCtJGXf3GP5ZiTw==
   dependencies:
-    "@eslint-community/eslint-plugin-eslint-comments" "^4.5.0"
+    "@eslint-community/eslint-plugin-eslint-comments" "^4.7.2"
     "@stylistic/eslint-plugin" "^4.4.1"
     "@typescript-eslint/utils" "^8.34.1"
     eslint "^9.29.0"
@@ -3124,7 +3124,7 @@ eslint-config-txo-typescript@^7.4.113:
     eslint-plugin-promise "^7.2.1"
     globals "^16.5.0"
     typescript-eslint "^8.45.0"
-    yargs "^17.7.2"
+    yargs "^17.7.3"
 
 eslint-import-context@^0.1.8:
   version "0.1.9"
@@ -4085,7 +4085,7 @@ ignore-walk@^8.0.0:
   dependencies:
     minimatch "^10.0.3"
 
-ignore@^5.0.5, ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.2:
+ignore@^5.0.5, ignore@^5.2.0, ignore@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
@@ -4094,6 +4094,11 @@ ignore@^7.0.0:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
+
+ignore@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.6.tgz#6a57aaef4c90df27ac3590875d29e8f11988c88e"
+  integrity sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==
 
 immutability-helper@^3.1.1:
   version "3.1.1"
@@ -8102,7 +8107,7 @@ yargs-parser@^22.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-22.0.0.tgz#87b82094051b0567717346ecd00fd14804b357c8"
   integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
 
-yargs@17.7.2, yargs@^17.0.0, yargs@^17.3.1, yargs@^17.7.2:
+yargs@17.7.2, yargs@^17.0.0, yargs@^17.3.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
@@ -8127,6 +8132,19 @@ yargs@^16.0.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.7.3:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^18.0.0:
   version "18.1.0"


### PR DESCRIPTION
Removes the project parser option from the eslint config, drops unused eslint-disable directives and refreshes the eslint config dependency.